### PR TITLE
fix: prevent scientific notation in amount

### DIFF
--- a/.yarn/versions/cddb9a16.yml
+++ b/.yarn/versions/cddb9a16.yml
@@ -1,0 +1,2 @@
+releases:
+  "@near-eth/nep141-erc20": patch

--- a/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
+++ b/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
@@ -100,7 +100,7 @@ export async function initiate ({
   // various attributes stored as arrays, to keep history of retries
   const transfer = {
     // attributes common to all transfer types
-    amount: (new Decimal(amount).times(10 ** decimals)).toString(),
+    amount: (new Decimal(amount).times(10 ** decimals)).toFixed(),
     completedStep: null,
     destinationTokenName,
     errors: [],

--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
@@ -110,7 +110,7 @@ export async function initiate ({
   // various attributes stored as arrays, to keep history of retries
   let transfer = {
     // attributes common to all transfer types
-    amount: (new Decimal(amount).times(10 ** decimals)).toString(),
+    amount: (new Decimal(amount).times(10 ** decimals)).toFixed(),
     completedStep: null,
     destinationTokenName,
     errors: [],


### PR DESCRIPTION
https://github.com/MikeMcl/decimal.js/issues/105

Prevent scientific notation on amount which is not compatible with web3