### PR TITLE
fix: prevent 2nd eth approval if another lock already pending

### DIFF
--- a/.yarn/versions/97953207.yml
+++ b/.yarn/versions/97953207.yml
@@ -1,0 +1,2 @@
+releases:
+  "@near-eth/nep141-erc20": patch

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -178,7 +178,7 @@ Step 2: Initiate a transfer
 Great, now your user is authenticated with both NEAR & Ethereum. Now let's say you have a form.
 
 ```html
-<form id="sendErc20ToNear>
+<form id="sendErc20ToNear">
   <input id="erc20Address" />
   <input id="amount" />
 </form>

--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
@@ -308,7 +308,6 @@ async function mint (transfer) {
   // able to correctly identify the transfer and see if the transaction
   // succeeded.
   setTimeout(async () => {
-    console.log('timeout before redirect')
     const balanceBefore = await getNep141Balance({
       erc20Address: transfer.sourceToken,
       user: transfer.recipient
@@ -334,7 +333,6 @@ async function mint (transfer) {
 
 export async function checkMint (transfer) {
   const id = urlParams.get('minting')
-  console.log('id: ', id, transfer)
   if (!id || id !== transfer.id) {
     return {
       ...transfer,


### PR DESCRIPTION
Fix for https://github.com/near/rainbow-bridge-frontend/issues/97