### PR TITLE
fix: don't checkStatus if wrong eth network

### DIFF
--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -7,7 +7,6 @@ import {
   Step,
   UnsavedTransfer
 } from './types'
-import { getEthProvider } from './utils'
 
 export { onChange } from './storage'
 export { setEthProvider, setNearConnection } from './utils'
@@ -135,20 +134,10 @@ export function decorate (
  * inProgress transfers remain
  */
 export async function checkStatusAll (
-  { loop, expectedEthChainId }: { loop?: number, expectedEthChainId?: string } = { loop: undefined, expectedEthChainId: undefined }
+  { loop }: { loop?: number } = { loop: undefined }
 ): Promise<void> {
   if (loop !== undefined && !Number.isInteger(loop)) {
     throw new Error('`loop` must be frequency, in milliseconds')
-  }
-  if (expectedEthChainId !== undefined && expectedEthChainId !== getEthProvider().chainId) {
-    // Don't check status if wrong eth network is selected in wallet to prevent false transfer error.
-    if (loop !== undefined) {
-      window.setTimeout(
-        () => { checkStatusAll({ loop, expectedEthChainId }).catch(console.error) },
-        loop
-      )
-    }
-    return
   }
 
   const inProgress = await get({
@@ -161,7 +150,7 @@ export async function checkStatusAll (
   // loop, if told to loop
   if (loop !== undefined) {
     window.setTimeout(
-      () => { checkStatusAll({ loop, expectedEthChainId }).catch(console.error) },
+      () => { checkStatusAll({ loop }).catch(console.error) },
       loop
     )
   }

--- a/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
+++ b/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
@@ -262,6 +262,14 @@ async function checkFinality (transfer) {
 // on the Near2EthClient.
 async function checkSync (transfer) {
   const web3 = new Web3(getEthProvider())
+  const ethNetwork = await web3.eth.net.getNetworkType()
+  if (ethNetwork !== process.env.ethNetworkId) {
+    console.log(
+      'Wrong eth network for checkSync, expected: %s, got: %s',
+      process.env.ethNetworkId, ethNetwork
+    )
+    return transfer
+  }
   const nearAccount = await getNearAccount()
 
   const nearOnEthClient = new web3.eth.Contract(
@@ -337,6 +345,14 @@ async function unlock (transfer) {
 
 async function checkUnlock (transfer) {
   const web3 = new Web3(getEthProvider())
+  const ethNetwork = await web3.eth.net.getNetworkType()
+  if (ethNetwork !== process.env.ethNetworkId) {
+    console.log(
+      'Wrong eth network for checkUnlock, expected: %s, got: %s',
+      process.env.ethNetworkId, ethNetwork
+    )
+    return transfer
+  }
 
   const unlockHash = last(transfer.unlockHashes)
   const unlockReceipt = await web3.eth.getTransactionReceipt(unlockHash)
@@ -346,7 +362,6 @@ async function checkUnlock (transfer) {
   if (!unlockReceipt.status) {
     let error
     try {
-      const ethNetwork = await web3.eth.net.getNetworkType()
       error = await getRevertReason(unlockHash, ethNetwork)
     } catch (e) {
       console.error(e)

--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
@@ -170,6 +170,14 @@ async function approve (transfer) {
 
 async function checkApprove (transfer) {
   const web3 = new Web3(getEthProvider())
+  const ethNetwork = await web3.eth.net.getNetworkType()
+  if (ethNetwork !== process.env.ethNetworkId) {
+    console.log(
+      'Wrong eth network for checkApprove, expected: %s, got: %s',
+      process.env.ethNetworkId, ethNetwork
+    )
+    return transfer
+  }
 
   const approvalHash = last(transfer.approvalHashes)
   const approvalReceipt = await web3.eth.getTransactionReceipt(
@@ -181,7 +189,6 @@ async function checkApprove (transfer) {
   if (!approvalReceipt.status) {
     let error
     try {
-      const ethNetwork = await web3.eth.net.getNetworkType()
       error = await getRevertReason(approvalHash, ethNetwork)
     } catch (e) {
       console.error(e)
@@ -235,6 +242,14 @@ async function lock (transfer) {
 async function checkLock (transfer) {
   const lockHash = last(transfer.lockHashes)
   const web3 = new Web3(getEthProvider())
+  const ethNetwork = await web3.eth.net.getNetworkType()
+  if (ethNetwork !== process.env.ethNetworkId) {
+    console.log(
+      'Wrong eth network for checkLock, expected: %s, got: %s',
+      process.env.ethNetworkId, ethNetwork
+    )
+    return transfer
+  }
   const lockReceipt = await web3.eth.getTransactionReceipt(
     lockHash
   )
@@ -244,7 +259,6 @@ async function checkLock (transfer) {
   if (!lockReceipt.status) {
     let error
     try {
-      const ethNetwork = await web3.eth.net.getNetworkType()
       error = await getRevertReason(lockHash, ethNetwork)
     } catch (e) {
       console.error(e)


### PR DESCRIPTION
Checking the status of a transfer must be done with the same Ethereum network for which that transfer was made i.e matching the bridge. Skip to the next loop until the provider chain id matches the expected chain id.