### PR TITLE
Fix block sync recovery

### DIFF
--- a/packages/nep141-erc20/package.json
+++ b/packages/nep141-erc20/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@near-eth/nep141-erc20",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "license": "(MIT AND Apache-2.0)",
   "main": "dist/index.js",
   "files": [

--- a/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
+++ b/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
@@ -69,6 +69,7 @@ export const i18n = {
 export function act (transfer) {
   switch (transfer.completedStep) {
     case null: return authenticate(transfer)
+    case AWAIT_FINALITY: return checkSync(transfer)
     case SYNC: return unlock(transfer)
     default: throw new Error(`Don't know how to act on transfer: ${JSON.stringify(transfer)}`)
   }


### PR DESCRIPTION
If the Near -> Eth sync query fails on AWAIT_FINALITY allowing retrying and calling checkSync again.

![Screen Shot 2021-03-04 at 11 01 55 PM](https://user-images.githubusercontent.com/29397451/109975965-94091680-7d3e-11eb-8ebc-9ea82d761b18.png)
