### PR TITLE
style: rename transfer steps

### DIFF
--- a/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
+++ b/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
@@ -36,9 +36,9 @@ export const i18n = {
   en_US: {
     steps: transfer => stepsFor(transfer, steps, {
       [WITHDRAW]: `Withdraw ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.sourceTokenName} from NEAR`,
-      [AWAIT_FINALITY]: 'Await NEAR finality for withdrawal transaction',
-      [SYNC]: 'Sync withdrawal transaction to Ethereum',
-      [UNLOCK]: `Unlock ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.destinationTokenName} in Ethereum`
+      [AWAIT_FINALITY]: `Convert ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.sourceTokenName} to ${transfer.destinationTokenName}`,
+      [SYNC]: 'Sync withdrawal transaction to Ethereum (up to 16 hours)',
+      [UNLOCK]: `Deposit ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.destinationTokenName} on Ethereum`
     }),
     statusMessage: transfer => {
       if (transfer.status === status.FAILED) return 'Failed'

--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
@@ -33,10 +33,10 @@ const steps = [
 export const i18n = {
   en_US: {
     steps: transfer => stepsFor(transfer, steps, {
-      [APPROVE]: `Approve Token Locker to spend ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.sourceTokenName}`,
-      [LOCK]: `Lock ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.sourceTokenName} in Token Locker`,
-      [SYNC]: `Sync ${transfer.neededConfirmations} blocks from Ethereum to NEAR`,
-      [MINT]: `Mint ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.destinationTokenName} in NEAR`
+      [APPROVE]: `Approve transfer of ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.sourceTokenName} from Ethereum`,
+      [LOCK]: `Convert ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.sourceTokenName} to ${transfer.destinationTokenName}`,
+      [SYNC]: `Wait for ${transfer.neededConfirmations} Ethereum confirmations for security`,
+      [MINT]: `Deposit ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.destinationTokenName} on NEAR`
     }),
     statusMessage: transfer => {
       if (transfer.status === status.FAILED) return 'Failed'


### PR DESCRIPTION
https://hackmd.io/wKy5TKXxQqGvQVIiOdVdUg
In case of Near -> Ethereum transfer back, these 2 steps can also be improved (and combined ?)
- ‘Await NEAR finality for withdrawal transaction’
- ‘Sync withdrawal transaction to Ethereum’
![image](https://user-images.githubusercontent.com/29397451/110740052-b71f5300-8275-11eb-99ee-aee0a2bdf7ea.png)

