### PR TITLE
fix: handle interrupted near tx (tab closed, go back...)

### DIFF
--- a/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
+++ b/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
@@ -363,6 +363,20 @@ export async function checkWithdraw (transfer) {
   // NOTE: when a single tx is executed, transactionHashes is equal to that hash
   const txHash = urlParams.get('transactionHashes')
   const errorCode = urlParams.get('errorCode')
+  if (!id && !txHash) {
+    // The user closed the tab and never rejected or approved the tx from Near wallet.
+    // This doesn't protect agains the user broadcasting a tx and closing the tab before
+    // redirect. So the dapp has no way of knowing the status of that transaction.
+    // Set status to FAILED so that it can be retried
+    const newError = `A withdraw transaction was initiated but could not be verified.
+      If a transaction was sent from your account, please make sure to 'Restore transfer' and finalize it.`
+    console.log(newError)
+    return {
+      ...transfer,
+      status: status.FAILED,
+      errors: [...transfer.errors, newError]
+    }
+  }
   if (!id) {
     // checkstatus managed to call checkWithdraw withing the 100ms before wallet redirect
     // so id is not yet set

--- a/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
+++ b/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
@@ -370,7 +370,7 @@ export async function checkWithdraw (transfer) {
     // Set status to FAILED so that it can be retried
     const newError = `A withdraw transaction was initiated but could not be verified.
       If a transaction was sent from your account, please make sure to 'Restore transfer' and finalize it.`
-    console.log(newError)
+    console.error(newError)
     return {
       ...transfer,
       status: status.FAILED,
@@ -384,11 +384,11 @@ export async function checkWithdraw (transfer) {
     return transfer
   }
   if (id !== transfer.id) {
-    // Wallet returns transaction hash in redirect so it is not possible for another
-    // withdraw transaction to be in process, ie if checkWithdraw is called on an in process
-    // withdraw then the transfer ids must be equal or the url callback is invalid.
+    // Another withdraw transaction cannot be in progress, ie if checkWithdraw is called on
+    // an in process withdraw then the transfer ids must be equal or the url callback is invalid.
     urlParams.clear()
-    const newError = 'Couldn\'t determine transaction outcome'
+    const newError = `Couldn't determine transaction outcome.
+      Got transfer id '${id} in URL, expected '${transfer.id}`
     console.error(newError)
     return {
       ...transfer,

--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
@@ -530,6 +530,20 @@ export async function checkMint (transfer) {
   // NOTE: when a single tx is executed, transactionHashes is equal to that hash
   const txHash = urlParams.get('transactionHashes')
   const errorCode = urlParams.get('errorCode')
+  if (!id && !txHash) {
+    // The user closed the tab and never rejected or approved the tx from Near wallet.
+    // This doesn't protect agains the user broadcasting a tx and closing the tab before
+    // redirect. So the dapp has no way of knowing the status of that transaction.
+    // Set status to FAILED so that it can be retried
+    const newError = `A deposit transaction was initiated but could not be verified.
+      If no transaction was sent from your account, please retry.`
+    console.error(newError)
+    return {
+      ...transfer,
+      status: status.FAILED,
+      errors: [...transfer.errors, newError]
+    }
+  }
   if (!id) {
     // checkstatus managed to call checkMint withing the 100ms before wallet redirect
     // so id is not yet set

--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
@@ -551,11 +551,11 @@ export async function checkMint (transfer) {
     return transfer
   }
   if (id !== transfer.id) {
-    // Wallet returns transaction hash in redirect so it is not possible for another
-    // minting transaction to be in process, ie if checkMint is called on an in process
-    // minting then the transfer ids must be equal or the url callback is invalid.
+    // Another minting transaction cannot be in progress, ie if checkMint is called on
+    // an in progess mint then the transfer ids must be equal or the url callback is invalid.
     urlParams.clear()
-    const newError = 'Couldn\'t determine transaction outcome'
+    const newError = `Couldn't determine transaction outcome.
+      Got transfer id '${id} in URL, expected '${transfer.id}`
     console.error(newError)
     return {
       ...transfer,


### PR DESCRIPTION
fixes https://github.com/near/rainbow-bridge-frontend/issues/154
Handle when a near tx is interrupted without a reject redirect from near wallet (user closes tab, clicks go back...)