### PR TITLE
feat: skip approval if enough allowance + handle speedup/cancel

### DIFF
--- a/.yarn/versions/df6f62e6.yml
+++ b/.yarn/versions/df6f62e6.yml
@@ -1,0 +1,5 @@
+releases:
+  "@near-eth/nep141-erc20": minor
+
+declined:
+  - "@near-eth/client"

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -130,18 +130,22 @@ export function decorate (
 const transfersToRemove: string[] = []
 
 /**
- * Record a transfer to be removed at the next status check
+ * Record a transfer to be removed at the next status check.
+ * This remove request will not be processed immediatly (at the next checkStatus loop)
+ * so apps may want to manually hide the transfer until it actually gets removed from storage.
  * @param transferId
  */
-export function remove(transferId: string) {
+export function remove (transferId: string): void {
   transfersToRemove.push(transferId)
 }
 
 /**
  * Process all pending transfer removal requests
  */
-async function checkPendingTransferRemovals () {
-  transfersToRemove.forEach(async transferId => await storage.clear(transferId))
+async function checkPendingTransferRemovals (): Promise<void> {
+  await Promise.all(transfersToRemove.map(
+    async transferId => await storage.clear(transferId)
+  ))
   transfersToRemove.splice(0, transfersToRemove.length)
 }
 

--- a/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
+++ b/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
@@ -54,7 +54,7 @@ const transferDraft = {
   // Cache eth tx information used for finding a replaced (speedup/cancel) tx.
   // ethCache: {
   //   signer,                   // tx.from of last broadcasted eth tx
-  //   safeReorgHight,           // Lower boundary for replacement tx search
+  //   safeReorgHeight,           // Lower boundary for replacement tx search
   //   nonce                     // tx.nonce of last broadcasted eth tx
   // }
 
@@ -580,7 +580,7 @@ async function unlock (transfer) {
 
   // If this tx is dropped and replaced, lower the search boundary
   // in case there was a reorg.
-  const safeReorgHight = await web3.eth.getBlockNumber() - 20
+  const safeReorgHeight = await web3.eth.getBlockNumber() - 20
   const unlockHash = await new Promise((resolve, reject) => {
     ethTokenLocker.methods
       .unlockToken(borshProof, nearOnEthClientBlockHeight).send()
@@ -594,7 +594,7 @@ async function unlock (transfer) {
     status: status.IN_PROGRESS,
     ethCache: {
       from: pendingUnlockTx.from,
-      safeReorgHight,
+      safeReorgHeight,
       nonce: pendingUnlockTx.nonce
     },
     unlockHashes: [...transfer.unlockHashes, unlockHash]
@@ -636,7 +636,7 @@ async function checkUnlock (transfer) {
           )
         }
       }
-      unlockReceipt = await findReplacementTx(transfer.ethCache.safeReorgHight, tx, event)
+      unlockReceipt = await findReplacementTx(transfer.ethCache.safeReorgHeight, tx, event)
     } catch (error) {
       console.error(error)
       return {

--- a/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
+++ b/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
@@ -39,6 +39,7 @@ const steps = [
 class TransferError extends Error {}
 
 const transferDraft = {
+  version: 1,
   // attributes common to all transfer types
   // amount,
   completedStep: null,
@@ -616,7 +617,7 @@ async function checkUnlock (transfer) {
   // If no receipt, check that the transaction hasn't been replaced (speedup or canceled)
   if (!unlockReceipt) {
     // don't break old transfers in case they were made before this functionality is released
-    if (!transfer.safeHeightBeforeEthTx || !transfer.latestEthTxNonce || !transfer.txFrom) return transfer
+    if (!transfer.version || !transfer.version >= 1) return transfer
     try {
       const tx = {
         nonce: transfer.latestEthTxNonce,

--- a/packages/nep141-erc20/src/natural-erc20/getAllowance.js
+++ b/packages/nep141-erc20/src/natural-erc20/getAllowance.js
@@ -1,0 +1,15 @@
+import Web3 from 'web3'
+import { getEthProvider } from '@near-eth/client/dist/utils'
+
+export default async function getAllowance (address, user, spender) {
+  if (!user || !spender) return null
+
+  const web3 = new Web3(getEthProvider())
+
+  const erc20Contract = new web3.eth.Contract(
+    JSON.parse(process.env.ethErc20AbiText),
+    address
+  )
+
+  return await erc20Contract.methods.allowance(user, spender).call()
+}

--- a/packages/nep141-erc20/src/natural-erc20/getAllowance.js
+++ b/packages/nep141-erc20/src/natural-erc20/getAllowance.js
@@ -1,15 +1,21 @@
 import Web3 from 'web3'
 import { getEthProvider } from '@near-eth/client/dist/utils'
 
-export default async function getAllowance (address, user, spender) {
-  if (!user || !spender) return null
+/**
+ * Returns the amount of erc20Address tokens which spender is allowed to withdraw from owner.
+ * @param {*} param.erc20Address
+ * @param {*} param.owner
+ * @param {*} param.spender
+ */
+export default async function getAllowance ({ erc20Address, owner, spender }) {
+  if (!owner || !spender) return null
 
   const web3 = new Web3(getEthProvider())
 
   const erc20Contract = new web3.eth.Contract(
     JSON.parse(process.env.ethErc20AbiText),
-    address
+    erc20Address
   )
 
-  return await erc20Contract.methods.allowance(user, spender).call()
+  return await erc20Contract.methods.allowance(owner, spender).call()
 }

--- a/packages/nep141-erc20/src/natural-erc20/index.js
+++ b/packages/nep141-erc20/src/natural-erc20/index.js
@@ -1,4 +1,5 @@
 export { default as getMetadata } from './getMetadata'
+export { default as getAllowance } from './getAllowance'
 export { default as getName } from './getName'
 export { initiate as sendToNear } from './sendToNear'
 export { recover } from './sendToNear'

--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
@@ -33,6 +33,7 @@ const steps = [
 ]
 
 const transferDraft = {
+  version: 1,
   // Attributes common to all transfer types
   // amount,
   completedStep: null,
@@ -283,7 +284,7 @@ async function checkApprove (transfer) {
   // If no receipt, check that the transaction hasn't been replaced (speedup or canceled)
   if (!approvalReceipt) {
     // don't break old transfers in case they were made before this functionality is released
-    if (!transfer.safeHeightBeforeEthTx || !transfer.latestEthTxNonce || !transfer.txFrom) return transfer
+    if (!transfer.version || !transfer.version >= 1) return transfer
     try {
       const tx = {
         nonce: transfer.latestEthTxNonce,

--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
@@ -48,7 +48,7 @@ const transferDraft = {
   // Cache eth tx information used for finding a replaced (speedup/cancel) tx.
   // ethCache: {
   //   signer,                   // tx.from of last broadcasted eth tx
-  //   safeReorgHight,           // Lower boundary for replacement tx search
+  //   safeReorgHeight,           // Lower boundary for replacement tx search
   //   nonce                     // tx.nonce of last broadcasted eth tx
   // }
 
@@ -247,7 +247,7 @@ async function approve (transfer) {
 
   // If this tx is dropped and replaced, lower the search boundary
   // in case there was a reorg.
-  const safeReorgHight = await web3.eth.getBlockNumber() - 20
+  const safeReorgHeight = await web3.eth.getBlockNumber() - 20
   const approvalHash = await new Promise((resolve, reject) => {
     erc20Contract.methods
       .approve(process.env.ethLockerAddress, transfer.amount).send()
@@ -260,7 +260,7 @@ async function approve (transfer) {
     ...transfer,
     ethCache: {
       from: pendingApprovalTx.from,
-      safeReorgHight,
+      safeReorgHeight,
       nonce: pendingApprovalTx.nonce
     },
     approvalHashes: [...transfer.approvalHashes, approvalHash],
@@ -303,7 +303,7 @@ async function checkApprove (transfer) {
           )
         }
       }
-      approvalReceipt = await findReplacementTx(transfer.ethCache.safeReorgHight, tx, event)
+      approvalReceipt = await findReplacementTx(transfer.ethCache.safeReorgHeight, tx, event)
     } catch (error) {
       console.error(error)
       return {
@@ -359,7 +359,7 @@ async function lock (transfer) {
 
   // If this tx is dropped and replaced, lower the search boundary
   // in case there was a reorg.
-  const safeReorgHight = await web3.eth.getBlockNumber() - 20
+  const safeReorgHeight = await web3.eth.getBlockNumber() - 20
   const lockHash = await new Promise((resolve, reject) => {
     ethTokenLocker.methods
       .lockToken(transfer.sourceToken, transfer.amount, transfer.recipient).send()
@@ -373,7 +373,7 @@ async function lock (transfer) {
     status: status.IN_PROGRESS,
     ethCache: {
       from: pendingLockTx.from,
-      safeReorgHight,
+      safeReorgHeight,
       nonce: pendingLockTx.nonce
     },
     lockHashes: [...transfer.lockHashes, lockHash]
@@ -416,7 +416,7 @@ async function checkLock (transfer) {
           )
         }
       }
-      lockReceipt = await findReplacementTx(transfer.ethCache.safeReorgHight, tx, event)
+      lockReceipt = await findReplacementTx(transfer.ethCache.safeReorgHeight, tx, event)
     } catch (error) {
       console.error(error)
       return {

--- a/packages/nep141-erc20/src/utils/index.js
+++ b/packages/nep141-erc20/src/utils/index.js
@@ -80,6 +80,5 @@ export async function findReplacementTx (safeHeightBeforeEthTx, tx, event) {
       with unexpected event: '${JSON.stringify(event)}'`
     throw new Error(error)
   }
-  console.log('Transaction speed up with: ', replacementTx.hash)
   return receipt
 }

--- a/packages/nep141-erc20/src/utils/index.js
+++ b/packages/nep141-erc20/src/utils/index.js
@@ -4,13 +4,12 @@ import { getEthProvider } from '@near-eth/client/dist/utils'
 /**
  * Search for a dropped and replaced transaction (speed up or cancel)
  * @param {Number} safeHeightBeforeEthTx Lower search bound
- * @param {*} txInfo Transaction information to find the replacement
- * @param {*} tx.nonce Nonce of the transaction searched
- * @param {*} tx.from Signer of the transaction searched
- * @param {*} tx.to Address called by the transaction searched
- * @param {*} event.name Name of event expected if tx was speed up
- * @param {*} event.abi tx.to contract abi needed to find event
- * @param {*} event.validate Function to validate the content of event
+ * @param {Number} tx.nonce Nonce of the transaction searched
+ * @param {String} tx.from Signer of the transaction searched
+ * @param {String} tx.to Address called by the transaction searched
+ * @param {String} event.name Name of event expected if tx was speed up
+ * @param {String} event.abi tx.to contract abi needed to find event
+ * @param {Function} event.validate Function to validate the content of event
  */
 export async function findReplacementTx (safeHeightBeforeEthTx, tx, event) {
   const web3 = new Web3(getEthProvider())

--- a/packages/nep141-erc20/src/utils/index.js
+++ b/packages/nep141-erc20/src/utils/index.js
@@ -1,0 +1,85 @@
+import Web3 from 'web3'
+import { getEthProvider } from '@near-eth/client/dist/utils'
+
+
+/**
+ * Search for a dropped and replaced transaction (speed up or cancel)
+ * @param {Number} safeHeightBeforeEthTx Lower search bound
+ * @param {*} txInfo Transaction information to find the replacement
+ * @param {*} eventVerifier Check event information to verify if it was a speed up
+ */
+export async function handleEthTxReplaced(
+  safeHeightBeforeEthTx,
+  {broadcastedNonce, txFrom, txTo},
+  {eventName, contractAbiText, validateEvent}
+) {
+  const web3 = new Web3(getEthProvider())
+
+  const currentNonce = await web3.eth.getTransactionCount(txFrom, 'latest')
+
+  // Transaction still pending
+  if (currentNonce <= broadcastedNonce) return null
+
+  // Binary search the block of replacement (canceled or speedup) transaction
+  // between safeHeightBeforeEthTx and latest.
+  let replacementTxBlock
+  let maxBlock = await web3.eth.getBlockNumber() // latest: chain head
+  let minBlock = safeHeightBeforeEthTx
+  while (minBlock <= maxBlock) {
+    const middleBlock = Math.floor((minBlock + maxBlock) / 2)
+    const middleNonce = await web3.eth.getTransactionCount(txFrom, middleBlock) - 1
+    if (middleNonce < broadcastedNonce) {
+      // middleBlock was mined before the tx with broadcasted nonce, so take next block as lower bound
+      minBlock = middleBlock + 1
+    } else if (middleNonce >= broadcastedNonce) {
+      // The middleBlock was mined after the tx with broadcastedNonce, so check if the account has a
+      // lower nonce at previous block which would mean that broadcastedNonce was mined in this middleBlock.
+      if (await web3.eth.getTransactionCount(txFrom, middleBlock - 1) - 1 < broadcastedNonce) {
+        // Confirm the nonce changed by checking the previous block:
+        // use previous block nonce `>=` broadcasted nonce in case there are multiple user tx
+        // in the previous block. If only 1 user tx, then `===` would work
+        replacementTxBlock = middleBlock
+        break
+      }
+      // Otherwise take the previous block as the higher bound
+      maxBlock = middleBlock - 1
+    }
+  }
+  if (!replacementTxBlock) {
+    const error = `Could not find replacement transaction. It may be due to a chain reorg.`
+    throw new Error(error)
+  }
+  const block = await web3.eth.getBlock(replacementTxBlock, true)
+  const replacementTx = block.transactions.find(
+    tx => tx.from.toLowerCase() === txFrom.toLowerCase() && tx.nonce === broadcastedNonce
+  )
+  if (!replacementTx) {
+    const error = `Error happened while searching replacement transaction.`
+    throw new Error(error)
+  }
+  if (replacementTx.to.toLowerCase() !== txTo.toLowerCase()) {
+    const error = `Transaction was dropped and replaced by '${replacementTx.hash}'`
+    throw new Error(error)
+  }
+  const receipt = await web3.eth.getTransactionReceipt(replacementTx.hash)
+  if (!receipt.status) {
+    const error = `Transaction was dropped and replaced by a failing transaction: '${replacementTx.hash}'`
+    throw new Error(error)
+  }
+  const tokenContract = new web3.eth.Contract(
+    JSON.parse(contractAbiText),
+    txTo
+  )
+  const events = await tokenContract.getPastEvents(eventName, {
+    fromBlock: receipt.blockNumber,
+    toBlock: receipt.blockNumber
+  })
+  const event = events.find(e => e.transactionHash === replacementTx.hash)
+  if (!validateEvent(event)) {
+    const error = `Transaction was dropped and replaced by '${replacementTx.hash}'
+      with unexpected event`
+    throw new Error(error)
+  }
+  console.log('found replacement')
+  return receipt
+}

--- a/packages/nep141-erc20/src/utils/index.js
+++ b/packages/nep141-erc20/src/utils/index.js
@@ -1,24 +1,24 @@
 import Web3 from 'web3'
 import { getEthProvider } from '@near-eth/client/dist/utils'
 
-
 /**
  * Search for a dropped and replaced transaction (speed up or cancel)
  * @param {Number} safeHeightBeforeEthTx Lower search bound
  * @param {*} txInfo Transaction information to find the replacement
- * @param {*} eventVerifier Check event information to verify if it was a speed up
+ * @param {*} tx.nonce Nonce of the transaction searched
+ * @param {*} tx.from Signer of the transaction searched
+ * @param {*} tx.to Address called by the transaction searched
+ * @param {*} event.name Name of event expected if tx was speed up
+ * @param {*} event.abi tx.to contract abi needed to find event
+ * @param {*} event.validate Function to validate the content of event
  */
-export async function handleEthTxReplaced(
-  safeHeightBeforeEthTx,
-  {broadcastedNonce, txFrom, txTo},
-  {eventName, contractAbiText, validateEvent}
-) {
+export async function findReplacementTx (safeHeightBeforeEthTx, tx, event) {
   const web3 = new Web3(getEthProvider())
 
-  const currentNonce = await web3.eth.getTransactionCount(txFrom, 'latest')
+  const currentNonce = await web3.eth.getTransactionCount(tx.from, 'latest')
 
   // Transaction still pending
-  if (currentNonce <= broadcastedNonce) return null
+  if (currentNonce <= tx.nonce) return null
 
   // Binary search the block of replacement (canceled or speedup) transaction
   // between safeHeightBeforeEthTx and latest.
@@ -27,14 +27,14 @@ export async function handleEthTxReplaced(
   let minBlock = safeHeightBeforeEthTx
   while (minBlock <= maxBlock) {
     const middleBlock = Math.floor((minBlock + maxBlock) / 2)
-    const middleNonce = await web3.eth.getTransactionCount(txFrom, middleBlock) - 1
-    if (middleNonce < broadcastedNonce) {
+    const middleNonce = await web3.eth.getTransactionCount(tx.from, middleBlock) - 1
+    if (middleNonce < tx.nonce) {
       // middleBlock was mined before the tx with broadcasted nonce, so take next block as lower bound
       minBlock = middleBlock + 1
-    } else if (middleNonce >= broadcastedNonce) {
-      // The middleBlock was mined after the tx with broadcastedNonce, so check if the account has a
-      // lower nonce at previous block which would mean that broadcastedNonce was mined in this middleBlock.
-      if (await web3.eth.getTransactionCount(txFrom, middleBlock - 1) - 1 < broadcastedNonce) {
+    } else if (middleNonce >= tx.nonce) {
+      // The middleBlock was mined after the tx with tx.nonce, so check if the account has a
+      // lower nonce at previous block which would mean that tx.nonce was mined in this middleBlock.
+      if (await web3.eth.getTransactionCount(tx.from, middleBlock - 1) - 1 < tx.nonce) {
         // Confirm the nonce changed by checking the previous block:
         // use previous block nonce `>=` broadcasted nonce in case there are multiple user tx
         // in the previous block. If only 1 user tx, then `===` would work
@@ -46,18 +46,18 @@ export async function handleEthTxReplaced(
     }
   }
   if (!replacementTxBlock) {
-    const error = `Could not find replacement transaction. It may be due to a chain reorg.`
+    const error = 'Could not find replacement transaction. It may be due to a chain reorg.'
     throw new Error(error)
   }
   const block = await web3.eth.getBlock(replacementTxBlock, true)
   const replacementTx = block.transactions.find(
-    tx => tx.from.toLowerCase() === txFrom.toLowerCase() && tx.nonce === broadcastedNonce
+    blockTx => blockTx.from.toLowerCase() === tx.from.toLowerCase() && blockTx.nonce === tx.nonce
   )
   if (!replacementTx) {
-    const error = `Error happened while searching replacement transaction.`
+    const error = 'Error happened while searching replacement transaction.'
     throw new Error(error)
   }
-  if (replacementTx.to.toLowerCase() !== txTo.toLowerCase()) {
+  if (replacementTx.to.toLowerCase() !== tx.to.toLowerCase()) {
     const error = `Transaction was dropped and replaced by '${replacementTx.hash}'`
     throw new Error(error)
   }
@@ -67,19 +67,19 @@ export async function handleEthTxReplaced(
     throw new Error(error)
   }
   const tokenContract = new web3.eth.Contract(
-    JSON.parse(contractAbiText),
-    txTo
+    JSON.parse(event.abi),
+    tx.to
   )
-  const events = await tokenContract.getPastEvents(eventName, {
+  const events = await tokenContract.getPastEvents(event.name, {
     fromBlock: receipt.blockNumber,
     toBlock: receipt.blockNumber
   })
-  const event = events.find(e => e.transactionHash === replacementTx.hash)
-  if (!validateEvent(event)) {
+  const foundEvent = events.find(e => e.transactionHash === replacementTx.hash)
+  if (!foundEvent || !event.validate(foundEvent)) {
     const error = `Transaction was dropped and replaced by '${replacementTx.hash}'
-      with unexpected event`
+      with unexpected event: '${JSON.stringify(event)}'`
     throw new Error(error)
   }
-  console.log('found replacement')
+  console.log('Transaction speed up with: ', replacementTx.hash)
   return receipt
 }


### PR DESCRIPTION
This PR started out as adding getAllowance() to enable skipping the approve step if allowance is already enough.

Ended up adding support for canceled/speedup (dropped and replaced) transactions for https://github.com/near/rainbow-bridge-frontend/issues/136.

The two are cleanly separated in their own commit.