### PR TITLE
fix: fix lock event search

### DIFF
--- a/.yarn/versions/9eb70cbd.yml
+++ b/.yarn/versions/9eb70cbd.yml
@@ -1,0 +1,2 @@
+releases:
+  "@near-eth/nep141-erc20": patch

--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/findProof.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/findProof.js
@@ -47,10 +47,11 @@ export default async function findProof (lockTxHash) {
     receipt.transactionIndex
   )
 
-  const [lockedEvent] = await ethTokenLocker.getPastEvents('Locked', {
-    filter: { transactionHash: lockTxHash },
-    fromBlock: receipt.blockNumber
+  const events = await ethTokenLocker.getPastEvents('Locked', {
+    fromBlock: receipt.blockNumber,
+    toBlock: receipt.blockNumber
   })
+  const lockedEvent = events.find(event => event.transactionHash === lockTxHash)
   // `log.logIndex` does not necessarily match the log's order in the array of logs
   const logIndexInArray = receipt.logs.findIndex(
     l => l.logIndex === lockedEvent.logIndex

--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
@@ -132,14 +132,13 @@ export async function recover (lockTxHash) {
     JSON.parse(process.env.ethLockerAbiText),
     process.env.ethLockerAddress
   )
-  const [lockedEvent] = await ethTokenLocker.getPastEvents('Locked', {
-    filter: { transactionHash: lockTxHash },
-    fromBlock: receipt.blockNumber
+  const events = await ethTokenLocker.getPastEvents('Locked', {
+    fromBlock: receipt.blockNumber,
+    toBlock: receipt.blockNumber
   })
-  if (lockedEvent.event !== 'Locked') {
-    throw new Error(
-      `Unable to process lock transaction, for event ${lockedEvent.event}, expected 'Locked'`
-    )
+  const lockedEvent = events.find(event => event.transactionHash === lockTxHash)
+  if (!lockedEvent) {
+    throw new Error(`Unable to process lock transaction event.`)
   }
   const erc20Address = lockedEvent.returnValues.token
   const amount = lockedEvent.returnValues.amount


### PR DESCRIPTION
Fix findProof: when searching for the lock event, filtering by transaction hash is not available so if the block contains more lock transactions, the proof may be build for the wrong event.
https://github.com/near/rainbow-bridge-client/issues/12