### PR TITLE
fix: reduce mint deposit 10x

### DIFF
--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
@@ -402,9 +402,9 @@ async function mint (transfer) {
       // 200Tgas: enough for execution, not too much so that a 2fa tx is within 300Tgas
       new BN('200' + '0'.repeat(12)),
       // We need to attach tokens because minting increases the contract state, by <600 bytes, which
-      // requires an additional 0.06 NEAR to be deposited to the account for state staking.
-      // Note technically 0.0537 NEAR should be enough, but we round it up to stay on the safe side.
-      new BN('100000000000000000000').mul(new BN('600'))
+      // requires an additional 0.006 NEAR to be deposited to the account for state staking.
+      // Note technically 0.00537 NEAR should be enough, but we round it up to stay on the safe side.
+      new BN('100000000000000000000').mul(new BN('60'))
     )
   }, 100)
 


### PR DESCRIPTION
The faucet at https://faucet.paras.id/ only mints slightly more than 0.006Ⓝ

The current Rainbow Bridge frontend deposits 10x that amount, 0.06Ⓝ, when minting fungible tokens in NEAR

The storage cost in NEAR went down 10x since the frontend logic was first written

We need to decrease this deposit amount to match what is minted by the Paras faucet