### PR TITLE
fix: status message typo & outdated error

### DIFF
--- a/packages/client/src/getTransferType.ts
+++ b/packages/client/src/getTransferType.ts
@@ -1,0 +1,18 @@
+import { ConnectorLib, Transfer } from './types'
+
+export function getTransferType (transfer: Transfer): ConnectorLib {
+  // TODO: find a way to `require(transfer.type)`
+  try {
+    switch (transfer.type) {
+      case '@near-eth/nep141-erc20/natural-erc20/sendToNear':
+        return require('@near-eth/nep141-erc20/dist/natural-erc20/sendToNear')
+      case '@near-eth/nep141-erc20/bridged-nep141/sendToEthereum':
+        return require('@near-eth/nep141-erc20/dist/bridged-nep141/sendToEthereum')
+      default:
+        throw new Error(`Unregistered library for transfer with type=${transfer.type}`)
+    }
+  } catch (depLoadError) {
+    console.error(depLoadError)
+    throw new Error(`Can't find library for transfer with type=${transfer.type}`)
+  }
+}

--- a/packages/client/src/i18nHelpers.ts
+++ b/packages/client/src/i18nHelpers.ts
@@ -1,5 +1,6 @@
 import { FAILED } from './statuses'
-import { Transfer, Step } from './types'
+import { Localizations, Transfer, Step } from './types'
+import { getTransferType } from './getTransferType'
 
 export function stepsFor (
   transfer: Transfer,
@@ -14,4 +15,38 @@ export function stepsFor (
       ? FAILED
       : i <= completed ? 'completed' : 'pending'
   }))
+}
+
+export function localizedError (
+  transfer: Transfer,
+  errorKey: string
+): string {
+  const type = getTransferType(transfer)
+  const i18n = type.i18n
+
+  // get user's locale from browser
+  const locale = navigator.language.replace('-', '_')
+
+  // get available & fallback locale from given i18n
+  const availableLocales = Object.keys(i18n)
+  const fallback = availableLocales[0] as string
+
+  // check if i18n includes localizations for browser's locale;
+  // fall back to fallback if not
+  let localized = i18n[locale]
+  if (localized === undefined) {
+    localized = i18n[fallback] as Localizations
+  }
+
+  // check if preferred localization contains error for given errorKey;
+  // fall back to fallback's error message if not
+  let error = localized.errors(transfer)[errorKey]
+  if (error === undefined) {
+    error = (i18n[fallback] as Localizations).errors(transfer)[errorKey]
+  }
+
+  if (error !== undefined) return error
+
+  console.error(`No defined error for errorKey=${errorKey} for locale=${locale} or fallback=${fallback}`)
+  return errorKey
 }

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,32 +1,15 @@
 import * as storage from './storage'
 import * as status from './statuses'
 import {
-  ConnectorLib,
   Transfer,
   DecoratedTransfer,
   Step,
   UnsavedTransfer
 } from './types'
+import { getTransferType } from './getTransferType'
 
 export { onChange } from './storage'
 export { setEthProvider, setNearConnection } from './utils'
-
-function getTransferType (transfer: Transfer): ConnectorLib {
-  // TODO: find a way to `require(transfer.type)`
-  try {
-    switch (transfer.type) {
-      case '@near-eth/nep141-erc20/natural-erc20/sendToNear':
-        return require('@near-eth/nep141-erc20/dist/natural-erc20/sendToNear')
-      case '@near-eth/nep141-erc20/bridged-nep141/sendToEthereum':
-        return require('@near-eth/nep141-erc20/dist/bridged-nep141/sendToEthereum')
-      default:
-        throw new Error(`Unregistered library for transfer with type=${transfer.type}`)
-    }
-  } catch (depLoadError) {
-    console.error(depLoadError)
-    throw new Error(`Can't find library for transfer with type=${transfer.type}`)
-  }
-}
 
 /**
  * Return a list of transfers

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -40,10 +40,11 @@ export type DecoratedTransfer = Transfer & {
   callToAction?: string
 }
 
-interface Localizations {
+export interface Localizations {
   steps: (t: Transfer) => Step[]
   callToAction: (t: Transfer) => string | null
   statusMessage: (t: Transfer) => string
+  errors: (t: Transfer) => { [key: string]: string }
 }
 
 export interface ConnectorLib {


### PR DESCRIPTION
* typo: transfering -> transferring
* outdated error: referencing "Lock" step instead of "Transfer" step

The outdated error message made me realize that the error messages were not included in the i18n, so I added them there and added a helper to `client/i18nHelpers` to access it.