### PR TITLE
fix: don't use WalletConnectProvider for receipt queries

### DIFF
--- a/.yarn/versions/219c0120.yml
+++ b/.yarn/versions/219c0120.yml
@@ -1,0 +1,2 @@
+releases:
+  "@near-eth/nep141-erc20": patch

--- a/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
+++ b/packages/nep141-erc20/src/bridged-nep141/sendToEthereum/index.js
@@ -619,7 +619,10 @@ async function unlock (transfer) {
 }
 
 async function checkUnlock (transfer) {
-  const web3 = new Web3(getEthProvider())
+  const provider = getEthProvider()
+  // If available connect to rpcUrl to avoid issues with WalletConnectProvider receipt.status
+  const web3 = new Web3(provider.rpcUrl ? provider.rpcUrl : provider)
+
   const ethNetwork = await web3.eth.net.getNetworkType()
   if (ethNetwork !== process.env.ethNetworkId) {
     console.log(

--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/findProof.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/findProof.js
@@ -31,7 +31,9 @@ const proofBorshSchema = new Map([
 // be passed to the FungibleTokenFactory contract, which verifies the proof
 // against a Prover contract.
 export default async function findProof (lockTxHash) {
-  const web3 = new Web3(getEthProvider())
+  const provider = getEthProvider()
+  // If available connect to rpcUrl to avoid issues with WalletConnectProvider receipt.status
+  const web3 = new Web3(provider.rpcUrl ? provider.rpcUrl : provider)
 
   const ethTokenLocker = new web3.eth.Contract(
     JSON.parse(process.env.ethLockerAbiText),
@@ -80,7 +82,9 @@ export default async function findProof (lockTxHash) {
 }
 
 async function buildTree (block) {
-  const web3 = new Web3(getEthProvider())
+  const provider = getEthProvider()
+  // If available connect to rpcUrl to avoid issues with WalletConnectProvider receipt.status
+  const web3 = new Web3(provider.rpcUrl ? provider.rpcUrl : provider)
 
   const blockReceipts = await Promise.all(
     block.transactions.map(t => web3.eth.getTransactionReceipt(t))
@@ -100,7 +104,9 @@ async function buildTree (block) {
 }
 
 async function extractProof (block, tree, transactionIndex) {
-  const web3 = new Web3(getEthProvider())
+  const provider = getEthProvider()
+  // If available connect to rpcUrl to avoid issues with WalletConnectProvider receipt.status
+  const web3 = new Web3(provider.rpcUrl ? provider.rpcUrl : provider)
 
   const [, , stack] = await promisfy(
     tree.findPath,

--- a/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
+++ b/packages/nep141-erc20/src/natural-erc20/sendToNear/index.js
@@ -134,7 +134,10 @@ export function checkStatus (transfer) {
  * @param {*} lockTxHash
  */
 export async function recover (lockTxHash) {
-  const web3 = new Web3(getEthProvider())
+  const provider = getEthProvider()
+  // If available connect to rpcUrl to avoid issues with WalletConnectProvider receipt.status
+  const web3 = new Web3(provider.rpcUrl ? provider.rpcUrl : provider)
+
   const receipt = await web3.eth.getTransactionReceipt(lockTxHash)
   const ethTokenLocker = new web3.eth.Contract(
     JSON.parse(process.env.ethLockerAbiText),
@@ -269,7 +272,10 @@ async function approve (transfer) {
 }
 
 async function checkApprove (transfer) {
-  const web3 = new Web3(getEthProvider())
+  const provider = getEthProvider()
+  // If available connect to rpcUrl to avoid issues with WalletConnectProvider
+  const web3 = new Web3(provider.rpcUrl ? provider.rpcUrl : provider)
+
   const ethNetwork = await web3.eth.net.getNetworkType()
   if (ethNetwork !== process.env.ethNetworkId) {
     console.log(
@@ -381,8 +387,11 @@ async function lock (transfer) {
 }
 
 async function checkLock (transfer) {
+  const provider = getEthProvider()
+  // If available connect to rpcUrl to avoid issues with WalletConnectProvider
+  const web3 = new Web3(provider.rpcUrl ? provider.rpcUrl : provider)
+
   const lockHash = last(transfer.lockHashes)
-  const web3 = new Web3(getEthProvider())
   const ethNetwork = await web3.eth.net.getNetworkType()
   if (ethNetwork !== process.env.ethNetworkId) {
     console.log(

--- a/packages/nep141-erc20/src/utils/index.js
+++ b/packages/nep141-erc20/src/utils/index.js
@@ -12,7 +12,9 @@ import { getEthProvider } from '@near-eth/client/dist/utils'
  * @param {Function} event.validate Function to validate the content of event
  */
 export async function findReplacementTx (safeHeightBeforeEthTx, tx, event) {
-  const web3 = new Web3(getEthProvider())
+  const provider = getEthProvider()
+  // If available connect to rpcUrl to avoid issues with WalletConnectProvider receipt.status
+  const web3 = new Web3(provider.rpcUrl ? provider.rpcUrl : provider)
 
   const currentNonce = await web3.eth.getTransactionCount(tx.from, 'latest')
 


### PR DESCRIPTION
This provider is giving inconsistent receipt.status results.
So connect web3 via rpcURL directly when transaction signing is not needed